### PR TITLE
Supporting different coredns configmaps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ If you've had problems with ingress-nginx, cert-manager, LetsEncrypt ACME HTTP01
 
 ## One-line install
 
+If your coredns uses a different configmap other than coredns, please modify COREDNS_CONFIGMAP_NAME env in the deployment file.
+
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/compumike/hairpin-proxy/v0.2.1/deploy.yml
+kubectl apply -f https://raw.githubusercontent.com/saithejareddy/hairpin-proxy/master/deploy.yml
 ```
 
 If you're using [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) and [cert-manager](https://github.com/jetstack/cert-manager), it will work out of the box. See detailed installation and testing instructions below.
@@ -71,8 +73,10 @@ The `dig` should show the external load balancer IP address. The first `curl` sh
 
 ### Step 1: Install hairpin-proxy in your Kubernetes cluster
 
+If your coredns uses a different configmap other than coredns, please modify COREDNS_CONFIGMAP_NAME env in the deployment file.
+
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/compumike/hairpin-proxy/v0.2.1/deploy.yml
+kubectl apply -f https://raw.githubusercontent.com/saithejareddy/hairpin-proxy/master/deploy.yml
 ```
 
 If you're using `ingress-nginx`, this will work as-is.
@@ -129,5 +133,5 @@ To resolve this, we need to rewrite the DNS on the Node itself. The Node does no
 To install this DaemonSet:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/compumike/hairpin-proxy/v0.2.1/deploy-etchosts-daemonset.yml
+kubectl apply -f https://raw.githubusercontent.com/saithejareddy/hairpin-proxy/master/deploy-etchosts-daemonset.yml
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ If you've had problems with ingress-nginx, cert-manager, LetsEncrypt ACME HTTP01
 
 ## One-line install
 
-If your coredns uses a different configmap other than coredns, please modify COREDNS_CONFIGMAP_NAME env in the deployment file.
+If your coredns uses a different configmap other than coredns, please modify COREDNS_CONFIGMAP_NAME env in the hairpin-proxy-controller deployment config.
+If you want to keep customized coredns config in different configmap, please set COREDNS_IMPORT_CONFIG to true in the hairpin-proxy-controller deployment config.
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/saithejareddy/hairpin-proxy/master/deploy.yml
@@ -73,7 +74,8 @@ The `dig` should show the external load balancer IP address. The first `curl` sh
 
 ### Step 1: Install hairpin-proxy in your Kubernetes cluster
 
-If your coredns uses a different configmap other than coredns, please modify COREDNS_CONFIGMAP_NAME env in the deployment file.
+If your coredns uses a different configmap other than coredns, please modify COREDNS_CONFIGMAP_NAME env in the hairpin-proxy-controller deployment config.
+If you want to keep customized coredns config in different configmap, please set COREDNS_IMPORT_CONFIG to true in the hairpin-proxy-controller deployment config.
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/saithejareddy/hairpin-proxy/master/deploy.yml

--- a/build_and_push
+++ b/build_and_push
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-(cd ./hairpin-proxy-haproxy && ./build_and_push)
-(cd ./hairpin-proxy-controller && ./build_and_push)
+(cd ./hairpin-proxy-haproxy && ./build_and_push $1)
+(cd ./hairpin-proxy-controller && ./build_and_push $1)

--- a/deploy.yml
+++ b/deploy.yml
@@ -152,6 +152,9 @@ spec:
         runAsGroup: 65533
       containers:
         - image: compumike/hairpin-proxy-controller:0.2.1
+          env:
+          - name: COREDNS_CONFIGMAP_NAME
+            value: "coredns"
           name: main
           resources:
             requests:

--- a/deploy.yml
+++ b/deploy.yml
@@ -23,7 +23,7 @@ spec:
         app: hairpin-proxy-haproxy
     spec:
       containers:
-        - image: compumike/hairpin-proxy-haproxy:0.2.1
+        - image: compumike/hairpin-proxy-haproxy:v0.1
           name: main
           resources:
             requests:
@@ -151,10 +151,12 @@ spec:
         runAsUser: 405
         runAsGroup: 65533
       containers:
-        - image: saitheja1926/hairpin-proxy-controller:0.2.1
+        - image: saitheja1926/hairpin-proxy-controller:v0.1
           env:
           - name: COREDNS_CONFIGMAP_NAME
-            value: "coredns"
+            value: "coredns-custom"
+          - name: COREDNS_IMPORT_CONFIG
+            value: true
           name: main
           resources:
             requests:

--- a/deploy.yml
+++ b/deploy.yml
@@ -151,7 +151,7 @@ spec:
         runAsUser: 405
         runAsGroup: 65533
       containers:
-        - image: compumike/hairpin-proxy-controller:0.2.1
+        - image: saitheja1926/hairpin-proxy-controller:0.2.1
           env:
           - name: COREDNS_CONFIGMAP_NAME
             value: "coredns"

--- a/hairpin-proxy-controller/build_and_push
+++ b/hairpin-proxy-controller/build_and_push
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-docker build -t compumike/hairpin-proxy-controller .
-docker push compumike/hairpin-proxy-controller
+docker build -t saitheja1926/hairpin-proxy-controller$1 .
+docker push saitheja1926/hairpin-proxy-controller$1

--- a/hairpin-proxy-controller/build_and_push
+++ b/hairpin-proxy-controller/build_and_push
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-docker build -t saitheja1926/hairpin-proxy-controller$1 .
-docker push saitheja1926/hairpin-proxy-controller$1
+docker build -t saitheja1926/hairpin-proxy-controller:$1 .
+docker push saitheja1926/hairpin-proxy-controller:$1

--- a/hairpin-proxy-controller/src/main.rb
+++ b/hairpin-proxy-controller/src/main.rb
@@ -24,18 +24,27 @@ class HairpinProxyController
     @log = Logger.new(STDOUT)
   end
 
-  def set_coredns_configmap_var
+  def set_coredns_env_var
 
     # This function looks up for coredns configmap name from env.
     # If not present, it uses default name coredns
     # Returning CoreDNS CM Variable
-    if ENV.key?('COREDNS_CONFIGMAP_NAME')
-      COREDNS_CM = ENV['COREDNS_CONFIGMAP_NAME']
+    if ENV.key?('COREDNS_IMPORT_CONFIG')
+      coredns_import = ENV.fetch(COREDNS_IMPORT_CONFIG)
+      @log.info("Info: Core DNS import feature enabled.. Syntax will be similar to import config...")
     else
-      COREDNS_CM = "coredns"
-      @log.warn("Info: No COREDNS_CONFIGMAP_NAME Environment Variable found.. Falling back to default configmap 'coredns'")
+      coredns_import = false
+      @log.info("Info: Core DNS import feature disabled.. Falling back to default syntax")
     end
-    return COREDNS_CM
+
+    if ENV.key?('COREDNS_CONFIGMAP_NAME')
+      coredns_cm = ENV.fetch('COREDNS_CONFIGMAP_NAME')
+      @log.info("Info: CoreDNS Custom ConfigMap Enabeld.. #{COREDNS_CONFIGMAP_NAME} will be modified for adding rewrite rules...")
+    else
+      coredns_cm = "coredns"
+      @log.info("Info: No COREDNS_CONFIGMAP_NAME Environment Variable found.. Falling back to default configmap 'coredns'")
+    end
+    return [coredns_import,coredns_cm]
   end
 
   def fetch_ingress_hosts
@@ -54,32 +63,48 @@ class HairpinProxyController
     hosts.sort.uniq
   end
 
-  def coredns_corefile_with_rewrite_rules(original_corefile, hosts)
+  def coredns_corefile_with_rewrite_rules(original_corefile, hosts,configmap_import_enabled)
     # Return a String representing the original CoreDNS Corefile, modified to include rewrite rules for each of *hosts.
     # This is an idempotent transformation because our rewrites are labeled with COMMENT_LINE_SUFFIX.
 
     # Extract base configuration, without our hairpin-proxy rewrites
+
     cflines = original_corefile.strip.split("\n").reject { |line| line.strip.end_with?(COMMENT_LINE_SUFFIX) }
 
     # Create rewrite rules
     rewrite_lines = hosts.map { |host| "    rewrite name #{host} #{DNS_REWRITE_DESTINATION} #{COMMENT_LINE_SUFFIX}" }
+    
+    if configmap_import_enabled = false
 
-    # Inject at the start of the main ".:53 { ... }" configuration block
-    main_server_line = cflines.index { |line| line.strip.start_with?(".:53 {") }
-    raise "Can't find main server line! '.:53 {' in Corefile" if main_server_line.nil?
-    cflines.insert(main_server_line + 1, *rewrite_lines)
+      # Inject at the start of the main ".:53 { ... }" configuration block
+      main_server_line = cflines.index { |line| line.strip.start_with?(".:53 {") }
+      raise "Can't find main server line! '.:53 {' in Corefile" if main_server_line.nil?
+      cflines.insert(main_server_line + 1, *rewrite_lines)
 
-    cflines.join("\n")
+      cflines.join("\n")
+    else
+
+      # Inject at the start of the main ".:53 { ... }" configuration block
+      cflines.insert(0, *rewrite_lines)
+
+      cflines.join("\n")
+    end
   end
 
   def check_and_rewrite_coredns
     @log.info("Polling all Ingress resources and CoreDNS configuration...")
     hosts = fetch_ingress_hosts
-    configmap_name = set_coredns_configmap_var
+    configmap_import_enabled,configmap_name = set_coredns_env_var
     cm = @k8s.api.resource("configmaps", namespace: "kube-system").get(configmap_name)
 
-    old_corefile = cm.data.Corefile
-    new_corefile = coredns_corefile_with_rewrite_rules(old_corefile, hosts)
+    if configmap_import_enabled != true
+      old_corefile = cm.data.Corefile
+    else
+      if cm&.data&.has_key?("hairping-proxy.include")
+        old_corefile = cm.data['hairping-proxy.include']
+      end
+    end
+      new_corefile = coredns_corefile_with_rewrite_rules(old_corefile, hosts,configmap_type)
 
     if old_corefile.strip != new_corefile.strip
       @log.info("Corefile has changed! New contents:\n#{new_corefile}\nSending updated ConfigMap to Kubernetes API server...")

--- a/hairpin-proxy-haproxy/build_and_push
+++ b/hairpin-proxy-haproxy/build_and_push
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-docker build -t compumike/hairpin-proxy-haproxy .
-docker push compumike/hairpin-proxy-haproxy
+docker build -t saitheja1926/hairpin-proxy-haproxy:$1 .
+docker push saitheja1926/hairpin-proxy-haproxy:$1


### PR DESCRIPTION
If user wants to use non-default coredns configmap or user wants to use import feature of coredns, it can be done by setting below 2 environment variables.

COREDNS_CONFIGMAP_NAME = <non-default-configmap-name>
COREDNS_IMPORT_CONFIG = true # To enable coredns import config feature

Ref:
https://coredns.io/plugins/import/